### PR TITLE
[Fix/#109] 공간 등록 페이지 개선 및 호스트 로그인 관련

### DIFF
--- a/frontend/src/app/host/page.tsx
+++ b/frontend/src/app/host/page.tsx
@@ -1,29 +1,27 @@
-'use client'
+"use client";
 
-import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
-import Image from 'next/image'
-import Link from 'next/link'
-import styles from './page.module.css'
-import HostHeader from '@/components/header/hostheader'
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+import styles from "./page.module.css";
+import HostHeader from "@/components/header/hostheader";
+import api from "@/lib/axios";
 
 interface User {
   isLoggedIn: boolean;
 }
 
 export default function HostMainPage() {
-  const router = useRouter()
-  const [user, setUser] = useState<User | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     // 로그인 상태 확인
     const checkLoginStatus = async () => {
       try {
-        const response = await fetch('/api/auth/check', {
-          credentials: 'include'
-        });
-        const data = await response.json();
+        const { data } = await api.get("/api/auth/check");
         setUser(data);
       } catch (error) {
         setUser({ isLoggedIn: false });
@@ -38,12 +36,12 @@ export default function HostMainPage() {
   // 보호된 경로 접근 핸들러
   const handleProtectedRoute = (path: string) => {
     if (!user?.isLoggedIn) {
-      alert('로그인이 필요한 서비스입니다.')
-      router.push('/host/login?redirect=' + encodeURIComponent(path))
-      return
+      alert("로그인이 필요한 서비스입니다.");
+      router.push("/host/login?redirect=" + encodeURIComponent(path));
+      return;
     }
-    router.push(path)
-  }
+    router.push(path);
+  };
 
   if (isLoading) {
     return (
@@ -55,14 +53,16 @@ export default function HostMainPage() {
 
   return (
     <div className={styles.container}>
-      <HostHeader isLoggedIn={user?.isLoggedIn || false} />
-      
+      <HostHeader />
+
       {/* Hero Section */}
       <section className={styles.heroSection}>
         <h1 className={styles.heroTitle}>당신의 공간을 LOCO와 함께</h1>
-        <p className={styles.heroSubtitle}>새로운 호스팅의 시작, LOCO와 함께하세요</p>
-        <button 
-          onClick={() => handleProtectedRoute('/host/spaces')} 
+        <p className={styles.heroSubtitle}>
+          새로운 호스팅의 시작, LOCO와 함께하세요
+        </p>
+        <button
+          onClick={() => handleProtectedRoute("/host/spaces")}
           className={styles.button}
         >
           호스트 시작하기
@@ -76,17 +76,23 @@ export default function HostMainPage() {
           <div className={styles.featureItem}>
             <div className={styles.featureIcon}>🏠</div>
             <h3 className={styles.featureTitle}>간편한 공간 등록</h3>
-            <p className={styles.featureDescription}>몇 번의 클릭만으로 당신의 공간을 등록할 수 있습니다.</p>
+            <p className={styles.featureDescription}>
+              몇 번의 클릭만으로 당신의 공간을 등록할 수 있습니다.
+            </p>
           </div>
           <div className={styles.featureItem}>
             <div className={styles.featureIcon}>📱</div>
             <h3 className={styles.featureTitle}>스마트한 예약 관리</h3>
-            <p className={styles.featureDescription}>실시간 예약 관리와 알림으로 편리하게 관리하세요.</p>
+            <p className={styles.featureDescription}>
+              실시간 예약 관리와 알림으로 편리하게 관리하세요.
+            </p>
           </div>
           <div className={styles.featureItem}>
             <div className={styles.featureIcon}>💰</div>
             <h3 className={styles.featureTitle}>안전한 정산 시스템</h3>
-            <p className={styles.featureDescription}>투명하고 안전한 정산으로 신뢰할 수 있는 호스팅</p>
+            <p className={styles.featureDescription}>
+              투명하고 안전한 정산으로 신뢰할 수 있는 호스팅
+            </p>
           </div>
         </div>
       </section>
@@ -112,9 +118,11 @@ export default function HostMainPage() {
       {/* CTA Section */}
       <section className={styles.ctaSection}>
         <h2 className={styles.ctaTitle}>지금 바로 LOCO 호스트가 되어보세요</h2>
-        <p className={styles.ctaDescription}>전문적인 호스트 매니저가 당신의 성공적인 호스팅을 도와드립니다</p>
-        <button 
-          onClick={() => handleProtectedRoute('/host/spaces')} 
+        <p className={styles.ctaDescription}>
+          전문적인 호스트 매니저가 당신의 성공적인 호스팅을 도와드립니다
+        </p>
+        <button
+          onClick={() => handleProtectedRoute("/host/spaces")}
           className={styles.button}
         >
           무료로 시작하기
@@ -126,17 +134,23 @@ export default function HostMainPage() {
         <h2 className={styles.sectionTitle}>호스트의 이야기</h2>
         <div className={styles.testimonialsGrid}>
           <div className={styles.testimonialItem}>
-            <p className={styles.testimonialQuote}>"LOCO와 함께하면서 공간 관리가 훨씬 수월해졌어요. 예약부터 정산까지 한 번에 해결할 수 있어서 좋습니다."</p>
+            <p className={styles.testimonialQuote}>
+              "LOCO와 함께하면서 공간 관리가 훨씬 수월해졌어요. 예약부터
+              정산까지 한 번에 해결할 수 있어서 좋습니다."
+            </p>
             <div className={styles.testimonialAuthor}>김서연</div>
             <div className={styles.testimonialRole}>카페 운영자</div>
           </div>
           <div className={styles.testimonialItem}>
-            <p className={styles.testimonialQuote}>"처음에는 걱정이 많았는데, LOCO의 호스트 매니저님이 친절하게 도와주셔서 쉽게 시작할 수 있었어요."</p>
+            <p className={styles.testimonialQuote}>
+              "처음에는 걱정이 많았는데, LOCO의 호스트 매니저님이 친절하게
+              도와주셔서 쉽게 시작할 수 있었어요."
+            </p>
             <div className={styles.testimonialAuthor}>이준호</div>
             <div className={styles.testimonialRole}>스튜디오 대표</div>
           </div>
         </div>
       </section>
     </div>
-  )
+  );
 }

--- a/frontend/src/app/host/spaces/register/complete/page.tsx
+++ b/frontend/src/app/host/spaces/register/complete/page.tsx
@@ -1,10 +1,10 @@
-'use client'
+"use client";
 
-import { useRouter } from 'next/navigation'
-import styles from './page.module.css'
+import { useRouter } from "next/navigation";
+import styles from "./page.module.css";
 
 export default function RegisterCompletePage() {
-  const router = useRouter()
+  const router = useRouter();
 
   return (
     <main className={styles.container}>
@@ -27,18 +27,19 @@ export default function RegisterCompletePage() {
         </div>
         <h1 className={styles.title}>저장이 완료되었습니다!</h1>
         <p className={styles.description}>
-          공간 등록이 성공적으로 완료되었습니다.<br />
+          공간 등록이 성공적으로 완료되었습니다.
+          <br />
           호스트 페이지에서 등록한 공간을 확인하실 수 있습니다.
         </p>
         <div className={styles.buttonGroup}>
           <button
-            onClick={() => router.push('/host/spaces')}
+            onClick={() => router.push("/host/spaces")}
             className={styles.primaryButton}
           >
             공간 목록 보기
-          </button>
+          </button>{" "}
           <button
-            onClick={() => router.push('/host/space/register')}
+            onClick={() => router.push("/host/spaces/register")}
             className={styles.secondaryButton}
           >
             새로운 공간 등록하기
@@ -46,5 +47,5 @@ export default function RegisterCompletePage() {
         </div>
       </div>
     </main>
-  )
-} 
+  );
+}

--- a/frontend/src/app/host/spaces/register/page.tsx
+++ b/frontend/src/app/host/spaces/register/page.tsx
@@ -51,7 +51,7 @@ export default function SpaceTypePage() {
     if (selectedTypes.length > 0) {
       // 선택된 공간 유형을 localStorage에 저장
       localStorage.setItem("selectedSpaceTypes", JSON.stringify(selectedTypes));
-      router.push("/host/space/register/details");
+      router.push("/host/spaces/register/details");
     }
   };
 

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -2,9 +2,9 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 export function middleware(request: NextRequest) {
-  // /spaces/register 경로를 /host/space/register로 리다이렉션
+  // /spaces/register 경로를 /host/spaces/register로 리다이렉션
   if (request.nextUrl.pathname === "/spaces/register") {
-    return NextResponse.redirect(new URL("/host/space/register", request.url));
+    return NextResponse.redirect(new URL("/host/spaces/register", request.url));
   }
 
   return NextResponse.next();

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,11 +1,12 @@
-import axios from 'axios';
+import axios from "axios";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8090/api/v1';
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8090/api/v1";
 
 const api = axios.create({
   baseURL: API_BASE_URL,
   headers: {
-    'Content-Type': 'application/json',
+    "Content-Type": "application/json",
   },
 });
 
@@ -14,7 +15,7 @@ export interface SignupRequest {
   email: string;
   password: string;
   phoneNumber: string;
-  type: 'GUEST' | 'HOST';
+  type: "GUEST" | "HOST";
 }
 
 export interface SignupResponse {
@@ -25,9 +26,18 @@ export interface SignupResponse {
   rating: number;
 }
 
+export interface HostRequestDto {
+  // businessName?: string;      // 사업자명
+  // businessNumber?: string;    // 사업자등록번호
+  bankName: string; // 은행명
+  bankAccountNumber: string; // 계좌번호
+  bankAccountHolder: string; // 예금주
+  description: string; // 호스트 소개
+}
+
 export const userApi = {
   signup: async (data: SignupRequest): Promise<SignupResponse> => {
-    const response = await api.post<SignupResponse>('/users', data);
+    const response = await api.post<SignupResponse>("/users", data);
     return response.data;
   },
 };
@@ -37,4 +47,4 @@ export const hostApi = {
     const response = await api.post(`/hosts/${userId}`, data);
     return response.data;
   },
-}; 
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #109 

## 📝작업 내용
<공간 등록 페이지의 리다이렉팅 경로 및 호스트 로그인의 isLoggedIn 오류 해결>
- [x] npm install @stomp/stompjs sockjs-client
➡️stomp, stomp 소켓 설치 (경로 : frontend)

- [x] isLoggedIn 문제 해결 : HostHeader에 isLoggedIn prop이 지원되지 않는다는 문제 해결
➡️axios의 api 를 import
➡️기존 fetch 호출 -> api의 get()으로 대체
➡️HostHeader isLoggedIn의 prop 제거 후 내부적으로 처리

- [x] services/api.ts 의 HostRequestDto 문제 해결 ➡️인터페이스 기반 필드 타입 추가

- [x] /host/spaces/register 경로와 /host/space/register 경로의 표준화 해결
* /host/spaces/register : 일부링크에서 사용
* /host/space/register : 미들웨어 도입으로 '미들웨어의 리다이렉션' 대상
* /host/space/register/details : 등록 상세 페이지 (ex. 기본정보 입력 등)
➡️middleware.ts 수정 (/spaces/register -> /host/spaces/register 경로로 표준화)
➡️상세페이지 이동 경로 수정 (/host/spaces/register/details)
➡️공간 등록 버튼 경로 (/host/spaces/register)로 수정

## 💬리뷰 요구사항
⭐표준화한 경로명 꼭 확인하세요.
⭐기존의 spaces/register 등록 페이지의 "1. 기본정보 페이지 | 2. 공간 정보 페이지 | 3. 이용 규칙" 부분을
host/spaces/register 등록 페이지의 "공간 유형 선택" 뒤로 추가한 것입니다.
그렇게되면 수정 구조는 "1. 공간 유형 선택 | 2. 기본정보 페이지 | 3. 공간 정보 페이지 | 4. 이용 규칙" 로 구성됩니다.
⭐spaces/register를 사용하지 않고 host/spaces/register에 옮긴 이유는 이해를 위해 다시 설명드리자면
호스트에서만 공간등록을 해야하기때문입니다.

### 스크린샷

![Image](https://github.com/user-attachments/assets/3e99ece1-5662-47fb-b319-c5c5702222bd)

![Image](https://github.com/user-attachments/assets/8564d064-9ff8-4397-ae3d-30a238b0c68d)

![Image](https://github.com/user-attachments/assets/35d8e1fb-cef0-49cf-ab0a-e2ab6a147689)

![Image](https://github.com/user-attachments/assets/87bdbb48-4e4d-472f-947b-78cd491ab989)

---
## 🚫닫을 이슈 (필수)
Closes #109
