### PR TITLE
[Refactor/#86] 전체 Swagger 관련 개선

### DIFF
--- a/backend/src/main/java/com/likelion/loco_project/domain/admin/controller/AdminController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/admin/controller/AdminController.java
@@ -6,11 +6,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.security.access.prepost.PreAuthorize;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/api/v1/admin/spaces")
 @RequiredArgsConstructor
 @PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "관리자", description = "관리자 관련 API, 공간 승인/반려")
 public class AdminController {
     private final SpaceService spaceService;
 

--- a/backend/src/main/java/com/likelion/loco_project/domain/admin/controller/AdminDashboardController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/admin/controller/AdminDashboardController.java
@@ -4,7 +4,7 @@ import com.likelion.loco_project.domain.admin.dto.*;
 import com.likelion.loco_project.domain.admin.service.AdminDashboardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -13,6 +13,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 @RequestMapping("/api/v1/admin/dashboard")
 @RequiredArgsConstructor
 @PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "관리자 대시보드", description = "관리자 대시보드 관련 API, 대시보드 요약 정보 조회 / 최근 예약 목록 조회 / 처리 대기 공간 목록 조회 / 월별 매출 데이터 조회 / 월별 예약 통계 조회 / 공간 유형별 분포 데이터 조회")
 public class AdminDashboardController {
     private final AdminDashboardService dashboardService;
 

--- a/backend/src/main/java/com/likelion/loco_project/domain/board/board/controller/ApiV1BoardController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/board/board/controller/ApiV1BoardController.java
@@ -5,6 +5,8 @@ import com.likelion.loco_project.domain.board.board.service.BoardService;
 import com.likelion.loco_project.global.exception.AccessDeniedException;
 import com.likelion.loco_project.global.exception.ResourceNotFoundException;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -16,12 +18,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/boards") // 기본 URL 경로 설정
+@Tag(name = "공간 게시판", description = "공간 게시판 관련 API, 호스트 - 공간 등록 / 게스트 - 공간 열람")
 public class ApiV1BoardController {
     private final BoardService boardService;
 
@@ -30,10 +33,17 @@ public class ApiV1BoardController {
      * @param pageable 페이징 및 정렬 정보를 담은 객체 (Spring Data JPA Pageable)
      * @return 페이징된 게시글 목록 정보와 함께 HTTP 상태 코드 200 (OK) 반환
      */
-    @Operation(summary = "게시글 목록 조회", description = "페이징 처리된 게시글 목록을 조회합니다.")
+    @Operation(
+        summary = "게시글 목록 조회",
+        description = "페이징 처리된 게시글 목록을 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공")
+        }
+    )
     @GetMapping
     public ResponseEntity<List<BoardListResponseDto>> getAllBoards(
-            @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable // 기본 페이징 설정
+            @Parameter(description = "페이지 정보 (size: 페이지당 항목 수, sort: 정렬 기준, direction: 정렬 방향)")
+            @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         // BoardService의 getAllBoards 메소드 호출하여 게시글 목록 조회 비즈니스 로직 수행
         // Service 메소드가 Page<BoardListResponseDto>를 반환하도록 변경할 수도 있습니다.
@@ -49,13 +59,19 @@ public class ApiV1BoardController {
      * @return 게시글 상세 정보와 함께 HTTP 상태 코드 200 (OK) 반환
      * @throws ResourceNotFoundException 게시글을 찾을 수 없을 때 발생
      */
-    @Operation(summary = "게시글 상세 조회", description = "게시글 ID로 특정 게시글의 상세 정보를 조회합니다.")
+    @Operation(
+        summary = "게시글 상세 조회",
+        description = "특정 게시글의 상세 정보를 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "게시글 상세 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음")
+        }
+    )
     @GetMapping("/{id}")
-    public ResponseEntity<BoardDetailResponseDto> getBoardById(@PathVariable Long id) { // @PathVariable로 경로 변수 값을 Long 타입 id로 받음
-        // BoardService의 getBoardById 메소드 호출하여 게시글 상세 조회 비즈니스 로직 수행
+    public ResponseEntity<BoardDetailResponseDto> getBoardById(
+            @Parameter(description = "조회할 게시글 ID", required = true, example = "1")
+            @PathVariable Long id) {
         BoardDetailResponseDto board = boardService.getBoardById(id);
-
-        // 조회된 게시글 상세 정보(DTO)와 함께 HTTP 상태 코드 200 (OK) 반환
         return ResponseEntity.ok(board);
     }
 

--- a/backend/src/main/java/com/likelion/loco_project/domain/board/comment/controller/ApiV1CommentController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/board/comment/controller/ApiV1CommentController.java
@@ -8,12 +8,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/boards/{boardId}/comments")
+@Tag(name = "댓글", description = "댓글 관련 API, 공간 게시판에 댓글 작성 / 수정 / 삭제")
 public class ApiV1CommentController {
     private final CommentService commentService;
 

--- a/backend/src/main/java/com/likelion/loco_project/domain/chat/controller/ApiV1ChatController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/chat/controller/ApiV1ChatController.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.*;
-
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
+@Tag(name = "채팅", description = "채팅 관련 API, 채팅방 생성 / 조회 / 메시지 전송 / 삭제 / 읽음 처리")
 public class ApiV1ChatController {
 
     private final ChatRoomService chatRoomService;

--- a/backend/src/main/java/com/likelion/loco_project/domain/guest/controller/ApiV1GuestController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/guest/controller/ApiV1GuestController.java
@@ -8,10 +8,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/api/v1/guests")
 @RequiredArgsConstructor
+@Tag(name = "게스트", description = "게스트 관련 API, 게스트 등록 / 조회")
 public class ApiV1GuestController {
     private final GuestService guestService;
 

--- a/backend/src/main/java/com/likelion/loco_project/domain/guestRating/controller/GuestRatingController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/guestRating/controller/GuestRatingController.java
@@ -3,6 +3,10 @@ package com.likelion.loco_project.domain.guestRating.controller;
 import com.likelion.loco_project.domain.guestRating.dto.GuestRatingRequestDto;
 import com.likelion.loco_project.domain.guestRating.dto.GuestRatingResponseDto;
 import com.likelion.loco_project.domain.guestRating.service.GuestRatingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -14,19 +18,41 @@ import java.math.BigDecimal;
 @RequestMapping("/api/v1/guest-rating")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "게스트 평점", description = "게스트 평점 관련 API")
 public class GuestRatingController {
 
     private final GuestRatingService guestRatingService;
 
+    @Operation(
+        summary = "게스트 평가",
+        description = "호스트가 게스트를 평가합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "평가 완료"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "게스트를 찾을 수 없음")
+        }
+    )
     @PostMapping
     public ResponseEntity<GuestRatingResponseDto> rateGuest(
-            @RequestHeader("hostId") Long hostId, // 임시 인증 방식
+            @Parameter(description = "평가하는 호스트 ID", required = true)
+            @RequestHeader("hostId") Long hostId,
+            @Parameter(description = "평가 정보", required = true)
             @RequestBody GuestRatingRequestDto dto) {
         return ResponseEntity.ok(guestRatingService.rateGuest(hostId, dto));
     }
-    //게스트의 평균 평점 열람
+
+    @Operation(
+        summary = "게스트 평균 평점 조회",
+        description = "특정 게스트의 평균 평점을 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "평균 평점 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "게스트를 찾을 수 없음")
+        }
+    )
     @GetMapping("/average/{guestId}")
-    public ResponseEntity<BigDecimal> getAverageRating(@PathVariable Long guestId) {
+    public ResponseEntity<BigDecimal> getAverageRating(
+            @Parameter(description = "평균 평점을 조회할 게스트 ID", required = true)
+            @PathVariable Long guestId) {
         log.info("게스트 ID {}의 평균 평점 조회 요청", guestId);
         BigDecimal average = guestRatingService.getAverageRatingForGuest(guestId);
         return ResponseEntity.ok(average);

--- a/backend/src/main/java/com/likelion/loco_project/domain/host/service/HostService.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/host/service/HostService.java
@@ -8,11 +8,15 @@ import com.likelion.loco_project.domain.user.dto.UserRequestDto;
 import com.likelion.loco_project.domain.user.entity.User;
 import com.likelion.loco_project.domain.user.entity.UserType;
 import com.likelion.loco_project.domain.user.repository.UserRepository;
+import com.likelion.loco_project.domain.user.service.UserService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +25,7 @@ public class HostService {
     private final HostRepository hostRepository;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final UserService userService;
 
     // 호스트 등록 기능
     @Transactional
@@ -89,8 +94,26 @@ public class HostService {
         hostRepository.save(host);
     }
 
+    // 호스트인지의 여부
     @Transactional(readOnly = true)
     public boolean isHost(Long userId) {
         return hostRepository.findByUserId(userId).isPresent();
+    }
+
+    // 호스트 로그인 검증
+    @Transactional(readOnly = true)
+    public Host loginAndValidate(String email, String password) {
+        User user = userService.loginAndValidate(email, password, UserType.HOST);
+        return hostRepository.findByUserId(user.getId())
+                .orElseThrow(() -> new IllegalArgumentException("호스트 정보를 찾을 수 없습니다."));
+    }
+
+    // 전체 호스트 조회 
+    @Transactional(readOnly = true)
+    public List<HostResponseDto> getAllHosts() {
+        List<Host> hosts = hostRepository.findAll();
+        return hosts.stream()
+                .map(HostResponseDto::new)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/likelion/loco_project/domain/mypage/controller/MyPageController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/mypage/controller/MyPageController.java
@@ -8,13 +8,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
-
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/mypage")
+@Tag(name = "마이페이지", description = "마이페이지 관련 API, 예약 조회 / 결제 조회")
 public class MyPageController {
 
     private final MyPageService myPageService;

--- a/backend/src/main/java/com/likelion/loco_project/domain/notification/controller/ApiV1NotificationController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/notification/controller/ApiV1NotificationController.java
@@ -12,12 +12,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/notifications")
+@Tag(name = "알림", description = "알림 관련 API, 알림 조회 / 읽음 처리 / 전체 읽음 처리 / 삭제")
 public class ApiV1NotificationController {
     private final NotificationService notificationService;
     private final NotificationSettingService notificationSettingService;

--- a/backend/src/main/java/com/likelion/loco_project/domain/payment/controller/ApiV1PaymentController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/payment/controller/ApiV1PaymentController.java
@@ -11,13 +11,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/payments")
 @RequiredArgsConstructor
+@Tag(name = "결제", description = "결제 관련 API, 결제 요청 / 완료 / 실패 / 환불")
 public class ApiV1PaymentController {
     private final PaymentService paymentService;
 

--- a/backend/src/main/java/com/likelion/loco_project/domain/report/controller/ReportController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/report/controller/ReportController.java
@@ -3,6 +3,10 @@ package com.likelion.loco_project.domain.report.controller;
 import com.likelion.loco_project.domain.report.dto.ReportRequestDto;
 import com.likelion.loco_project.domain.report.dto.ReportResponseDto;
 import com.likelion.loco_project.domain.report.service.ReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -10,13 +14,25 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/report")
 @RequiredArgsConstructor
+@Tag(name = "신고 관리", description = "리뷰 신고 관련 API")
 public class ReportController {
 
     private final ReportService reportService;
 
+    @Operation(
+        summary = "리뷰 신고",
+        description = "특정 리뷰를 신고합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "신고 접수 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음")
+        }
+    )
     @PostMapping("/review")
     public ResponseEntity<ReportResponseDto> reportReview(
-            @RequestHeader("guestId") Long guestId, // 임시 인증 방식
+            @Parameter(description = "신고하는 게스트 ID", required = true)
+            @RequestHeader("guestId") Long guestId,
+            @Parameter(description = "신고 정보", required = true)
             @RequestBody ReportRequestDto requestDto) {
 
         ReportResponseDto response = reportService.reportReview(guestId, requestDto);

--- a/backend/src/main/java/com/likelion/loco_project/domain/reservation/controller/ApiV1ReservationController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/reservation/controller/ApiV1ReservationController.java
@@ -6,11 +6,12 @@ import com.likelion.loco_project.domain.reservation.service.ReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/reservations")
+@Tag(name = "예약", description = "예약 관련 API, 예약 생성 / 조회 / 취소")
 public class ApiV1ReservationController {
 
     private final ReservationService reservationService;

--- a/backend/src/main/java/com/likelion/loco_project/domain/review/controller/GuestReviewController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/review/controller/GuestReviewController.java
@@ -3,6 +3,10 @@ package com.likelion.loco_project.domain.review.controller;
 import com.likelion.loco_project.domain.review.dto.ReviewRequestDto;
 import com.likelion.loco_project.domain.review.dto.ReviewResponseDto;
 import com.likelion.loco_project.domain.review.service.ReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -14,42 +18,96 @@ import java.util.List;
 @RequestMapping("/api/v1/guest/reviews")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "게스트 리뷰", description = "게스트 리뷰 관련 API")
 public class GuestReviewController {
 
     private final ReviewService reviewService;
 
+    @Operation(
+        summary = "리뷰 작성",
+        description = "게스트가 새로운 리뷰를 작성합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "리뷰 작성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+        }
+    )
     @PostMapping
-    public ReviewResponseDto createReview(@RequestBody ReviewRequestDto requestDto,
-                                          @RequestParam Long guestId) {
+    public ReviewResponseDto createReview(
+            @Parameter(description = "리뷰 정보", required = true)
+            @RequestBody ReviewRequestDto requestDto,
+            @Parameter(description = "리뷰 작성자 ID", required = true)
+            @RequestParam Long guestId) {
         return reviewService.createReview(guestId, requestDto);
     }
 
+    @Operation(
+        summary = "리뷰 수정",
+        description = "게스트가 작성한 리뷰를 수정합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "리뷰 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음")
+        }
+    )
     @PutMapping("/{reviewId}")
-    public ReviewResponseDto updateReview(@PathVariable Long reviewId,
-                                          @RequestParam Long guestId,
-                                          @RequestBody ReviewRequestDto requestDto) {
+    public ReviewResponseDto updateReview(
+            @Parameter(description = "수정할 리뷰 ID", required = true)
+            @PathVariable Long reviewId,
+            @Parameter(description = "리뷰 작성자 ID", required = true)
+            @RequestParam Long guestId,
+            @Parameter(description = "수정할 리뷰 정보", required = true)
+            @RequestBody ReviewRequestDto requestDto) {
         return reviewService.updateReview(reviewId, guestId, requestDto);
     }
 
+    @Operation(
+        summary = "리뷰 삭제",
+        description = "게스트가 작성한 리뷰를 삭제합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "리뷰 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음")
+        }
+    )
     @DeleteMapping("/{reviewId}")
-    public void deleteReview(@PathVariable Long reviewId,
-                             @RequestParam Long guestId) {
+    public void deleteReview(
+            @Parameter(description = "삭제할 리뷰 ID", required = true)
+            @PathVariable Long reviewId,
+            @Parameter(description = "리뷰 작성자 ID", required = true)
+            @RequestParam Long guestId) {
         reviewService.deleteReview(reviewId, guestId);
     }
 
+    @Operation(
+        summary = "공간별 리뷰 조회",
+        description = "특정 공간의 리뷰 목록을 조회합니다. 정렬 기준을 지정할 수 있습니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "리뷰 목록 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "공간을 찾을 수 없음")
+        }
+    )
     @GetMapping("/space/{spaceId}")
     public ResponseEntity<List<ReviewResponseDto>> getReviewsBySpace(
+            @Parameter(description = "리뷰를 조회할 공간 ID", required = true)
             @PathVariable Long spaceId,
-            @RequestParam(defaultValue = "latest") String sort
-    ) {
+            @Parameter(description = "정렬 기준 (latest: 최신순, rating-desc: 평점 높은순, rating-asc: 평점 낮은순)", example = "latest")
+            @RequestParam(defaultValue = "latest") String sort) {
         log.info("공간 {}에 대한 리뷰 조회 요청 - 정렬: {}", spaceId, sort);
         return ResponseEntity.ok(reviewService.getReviewsBySpace(spaceId, sort));
     }
 
+    @Operation(
+        summary = "게스트별 리뷰 조회",
+        description = "특정 게스트가 작성한 리뷰 목록을 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "리뷰 목록 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "게스트를 찾을 수 없음")
+        }
+    )
     @GetMapping("/guest/{guestId}")
-    public ResponseEntity<List<ReviewResponseDto>> getReviewsByGuest(@PathVariable Long guestId) {
+    public ResponseEntity<List<ReviewResponseDto>> getReviewsByGuest(
+            @Parameter(description = "리뷰를 조회할 게스트 ID", required = true)
+            @PathVariable Long guestId) {
         log.info("게스트 {}의 리뷰 조회 요청", guestId);
         return ResponseEntity.ok(reviewService.getReviewsByGuest(guestId));
     }
-
 }

--- a/backend/src/main/java/com/likelion/loco_project/domain/space/controller/ApiV1SpaceImageController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/space/controller/ApiV1SpaceImageController.java
@@ -17,7 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/spaces/images")
 @CrossOrigin(origins = "http://localhost:3000", allowCredentials = "true")  // 직접 origin 지정
-@Tag(name = "Space Images", description = "공간 이미지 관리 API")
+@Tag(name = "공간의 이미지", description = "공간 이미지 관리 API")
 public class ApiV1SpaceImageController {
     private final S3Service s3Service;
 

--- a/backend/src/main/java/com/likelion/loco_project/domain/space/controller/PlaceholderImageController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/space/controller/PlaceholderImageController.java
@@ -1,5 +1,9 @@
 package com.likelion.loco_project.domain.space.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
@@ -9,11 +13,22 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/placeholder.svg")
 @CrossOrigin(origins = "http://localhost:3000", allowCredentials = "true")
+@Tag(name = "기본 이미지", description = "기본 이미지(placeholder) 관련 API")
 public class PlaceholderImageController {
 
+    @Operation(
+        summary = "기본 이미지 조회",
+        description = "이미지 로딩 실패 시 사용할 기본 이미지를 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "기본 이미지 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "기본 이미지를 찾을 수 없음")
+        }
+    )
     @GetMapping
     public ResponseEntity<Resource> getPlaceholderImage(
+            @Parameter(description = "이미지 너비 (기본값: 300)", example = "300")
             @RequestParam(defaultValue = "300") int width,
+            @Parameter(description = "이미지 높이 (기본값: 200)", example = "200")
             @RequestParam(defaultValue = "200") int height) {
         try {
             // 기본 placeholder 이미지 반환

--- a/backend/src/main/java/com/likelion/loco_project/domain/user/controller/ApiV1UserController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/user/controller/ApiV1UserController.java
@@ -9,6 +9,7 @@ import com.likelion.loco_project.domain.user.service.UserService;
 import com.likelion.loco_project.global.jwt.JwtUtil;
 import com.likelion.loco_project.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
+@Tag(name = "유저", description = "유저 관련 API")
 public class ApiV1UserController {
     private final UserService userService;
     private final JwtUtil jwtUtil;
@@ -47,7 +49,8 @@ public class ApiV1UserController {
     public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto loginRequest) {
         User user = userService.loginAndValidate(loginRequest.getEmail(), loginRequest.getPassword());
         String token = jwtUtil.generateToken(user.getEmail());
-        return ResponseEntity.ok(new LoginResponseDto(token));
+        LoginResponseDto response = new LoginResponseDto(token, "로그인 완료!", user.getId());
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "사용자 정보 수정", description = "기존 사용자의 정보를 수정합니다.")
@@ -66,6 +69,7 @@ public class ApiV1UserController {
     }
 
     //유저 알림 기능 끄기(채팅, 예약상태 선택가능)
+    @Operation(summary = "유저 알림 기능 끄기", description = "유저 알림 기능 끄기(채팅, 예약상태 선택가능)")
     @PutMapping("/me/notifications/toggle")
     public ResponseEntity<RsData<Boolean>> toggleNotification(@AuthenticationPrincipal User user) {
         boolean updated = userService.toggleNotification(user.getId());
@@ -73,6 +77,7 @@ public class ApiV1UserController {
     }
 
     // 유저 알림 상태 조회
+    @Operation(summary = "유저 알림 상태 조회", description = "유저 알림 상태 조회")
     @GetMapping("/me/notifications/enabled")
     public ResponseEntity<RsData<Boolean>> isNotificationEnabled(@AuthenticationPrincipal User user) {
         boolean enabled = userService.isNotificationEnabled(user.getId());

--- a/backend/src/main/java/com/likelion/loco_project/domain/user/dto/LoginResponseDto.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/user/dto/LoginResponseDto.java
@@ -7,4 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class LoginResponseDto {
     private String token;
+    private String message;
+    private Long hostId;
 }

--- a/backend/src/main/java/com/likelion/loco_project/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/user/service/UserService.java
@@ -97,15 +97,22 @@ public class UserService {
 //                .rating(user.getRating())
 //                .build();
 //    }
-    public User loginAndValidate(String email, String rawPassword) {
+    public User loginAndValidate(String email, String password) {
         User user = userRepository.findByEmail(email)
-                .filter(u -> !u.isDeleted())
-                .orElseThrow(() -> new RuntimeException("해당 이메일의 사용자가 없습니다."));
-
-        if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
-            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+                .orElseThrow(() -> new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다."));
+        
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다.");
         }
+        
+        return user;
+    }
 
+    public User loginAndValidate(String email, String password, UserType requiredType) {
+        User user = loginAndValidate(email, password);
+        if (user.getUserType() != requiredType) {
+            throw new IllegalArgumentException(requiredType + " 계정이 아닙니다.");
+        }
         return user;
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #86 

## 📝작업 내용

- [x] 전체 호스트를 조회할 수 있는 Swagger 테스트 필요 (HostController에 추가)

- [x] swagger에서 공간이 등록되었을 경우에도 CODE 200 만 출력되는 것이 아닌 “공간 생성 완료” 및 “host id = spaceName” 이 같이 출력 (ex. “{id}번 호스트 = 서울 강남점 스터디룸 A”)

- [x] swagger에서 공간을 수정한 후에도 CODE 200만 출력되는 것이 아닌 “공간 수정 완료” 및 수정된 내용을 직관적으로 표시
ex. 변경된 내용 : [ 변경된 필드 기입 ] “MEETING” to “PARTY”
ex. 변경된 내용 : [ price ] “0” to “10000”

- [x] Host의 isHost와 User의 userType이 중복되는 문제
➡️User의 userType을 통해 권한 체크를 표준화시켜서 각 컨트롤러는 자신의 서비스만 사용하도록 수정
이를 통해 엔티티들의 관계가 더 명확해짐
관련 메소드 : loginAndValidate()

- [ ] 데이터의 단건을 조회하거나 특정 데이터를 조회할때 api포인트가 {id} 처럼 파라미터를 요구하고있지만 Swagger에서는 파라미터를 입력할 필드가 활성화되어있지 않음 (ex. No Parameters) ➡️따라서 파라미터를 입력할 수 있는 필드를 추가

### 스크린샷

### 유저 로그인 Swagger 테스트 문구

![Image](https://github.com/user-attachments/assets/bd826d45-7c8c-4005-9989-f5a196c47283)

### 호스트 로그인 Swagger 테스트 문구

![Image](https://github.com/user-attachments/assets/2e1860fe-d04d-491a-be07-424e93265f54)

![Image](https://github.com/user-attachments/assets/8b3240fc-f6f5-4fd6-a295-a30c5099bf0d)

---
### Swagger 개선

- 기존
![Image](https://github.com/user-attachments/assets/ebd9cbb2-1619-4197-8f1f-bb580a4313cf)

- 변경
![Image](https://github.com/user-attachments/assets/c9acf37d-62c2-42e9-a05c-40e536c4d4ed)

---
### 데이터 단 건 조회 시의 파라미터 추가

- 기존 (ex. 공간)
![Image](https://github.com/user-attachments/assets/a8380094-bbe1-4f6e-911c-d5756a152156)

---
## 🚫닫을 이슈 (필수)
Closes #86
