### PR TITLE
[Fix/#110] 프론트엔드 메인페이지 게스트 로그인 유지 수정

### DIFF
--- a/backend/src/main/java/com/likelion/loco_project/domain/user/controller/ApiV1UserController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/user/controller/ApiV1UserController.java
@@ -47,7 +47,7 @@ public class ApiV1UserController {
     public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto loginRequest) {
         User user = userService.loginAndValidate(loginRequest.getEmail(), loginRequest.getPassword());
         String token = jwtUtil.generateToken(user.getEmail());
-        return ResponseEntity.ok(new LoginResponseDto(token));
+        return ResponseEntity.ok(new LoginResponseDto(token, user.getUsername()));
     }
 
     @Operation(summary = "사용자 정보 수정", description = "기존 사용자의 정보를 수정합니다.")

--- a/backend/src/main/java/com/likelion/loco_project/domain/user/dto/LoginResponseDto.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/user/dto/LoginResponseDto.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class LoginResponseDto {
     private String token;
+    private String username; // 로그인 유지를 위한 사용자 이름 표시 필드
 }

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -36,8 +36,17 @@ export default function LoginPage() {
         // 로그인 성공 시 처리
         const data = await response.json();
         // TODO: 토큰 저장 로직 추가
-        alert('로그인 성공!');
-        router.push('/'); // 메인 페이지로 이동
+        // 백엔드 응답 구조에 따라 토큰 필드 이름을 확인해야 합니다.
+        // 예시: data.token 또는 data.accessToken
+        if (data.token) { // 백엔드 응답에 'token' 필드가 있다고 가정
+          localStorage.setItem('token', data.token);
+          localStorage.setItem('username', data.username); // 사용자 이름 저장
+          // localStorage.setItem('userId', data.id); // 사용자 ID 또는 호스트 ID 저장 (필요하다면)
+          alert('로그인 성공!');
+          router.push('/'); // 메인 페이지로 이동
+        } else {
+           setError('로그인 성공했지만 토큰이 응답에 없습니다.');
+        }
       } else {
         const errorData = await response.json();
         setError(errorData.message || '로그인에 실패했습니다.');

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,10 +1,43 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 import { FiMenu, FiSearch, FiBell, FiUser } from "react-icons/fi";
 import { IoIosArrowBack, IoIosArrowForward } from "react-icons/io";
 import { FaInstagram, FaTwitter, FaYoutube } from "react-icons/fa";
+import { useEffect, useState } from 'react';
 
 export default function Home() {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [username, setUsername] = useState('');
+
+  useEffect(() => {
+    // 클라이언트 사이드에서만 Local Storage 접근
+    if (typeof window !== 'undefined') {
+      const token = localStorage.getItem('token');
+      const storedUsername = localStorage.getItem('username');
+      if (token && storedUsername) {
+        setIsLoggedIn(true);
+        setUsername(storedUsername);
+      } else {
+        setIsLoggedIn(false);
+        setUsername('');
+      }
+    }
+  }, []); // 컴포넌트 마운트 시 한 번만 실행
+
+  const handleLogout = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('token');
+      localStorage.removeItem('username');
+      setIsLoggedIn(false);
+      setUsername('');
+      alert('로그아웃되었습니다.');
+      // 필요한 경우 로그아웃 후 리다이렉트
+      // window.location.href = '/login';
+    }
+  };
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}
@@ -27,7 +60,23 @@ export default function Home() {
                 className="bg-transparent border-none outline-none text-base w-48"
               />
             </div>
-            <Link href="/login" className="ml-2 text-base font-medium hover:text-blue-500">로그인</Link>
+            
+            {isLoggedIn ? (
+              // 로그인 상태일 때 표시
+              <div className="flex items-center gap-2">
+                <span className="text-base font-medium text-gray-700">{username}님 환영합니다!</span>
+                <button 
+                  onClick={handleLogout} 
+                  className="text-base font-medium text-gray-600 hover:text-gray-900"
+                >
+                  로그아웃
+                </button>
+              </div>
+            ) : (
+              // 로그인 상태가 아닐 때 표시
+              <Link href="/login" className="ml-2 text-base font-medium hover:text-blue-500">로그인</Link>
+            )}
+            
             <button className="p-2">
               <FiBell className="text-gray-600 text-xl" />
             </button>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #110 

## 📝작업 내용

- [x] 게스트 로그인 시 (localhost:3000/login)으로 리다이렉트되던 문제 해결 (메인페이지로 이동)
- [x] 게스트 로그인 후 메인페이지에서 로그인 유지가 되지 않던 문제 해결 (이름 및 로그아웃 출력으로 변경)

### 스크린샷

- 변경 (로그인을 해도 '로그인' 버튼이 활성화되었던 문제 ➡️ 로그인 유지를 위해 userId를 받아오고 로그아웃 버튼을 활성화하도록 app/page.tsx 변경)
![Image](https://github.com/user-attachments/assets/913c1485-4d8f-4e3c-8e17-f268d1a65b23)

### 리뷰 요구사항
- 호스트/게스트/유저 관련한 수정 계획 전에 만들었던 기능입니다.
- 호스트/게스트의 별도 로그인 관리가 아닌 유저로 로그인 후 권한을 관리하는 것에 대한 계획 전 만들었던 기능입니다.
- ⚠️따라서 호스트/게스트 별도 로그인 관리 PR 전 이 PR부터 병합을 진행해야합니다.

---
## 🚫닫을 이슈 (필수)
Closes #110
