### PR TITLE
[Feature/#90] 관리자 페이지 - 전체 예약 및 결제 관리 추가

### DIFF
--- a/backend/src/main/java/com/likelion/loco_project/domain/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/notification/service/NotificationService.java
@@ -119,12 +119,12 @@ public class NotificationService {
     }
 
     // 예약 상태 enum을 사용자 친화적 메시지로 변환
-    private String getReservationStatusMessage(ReservationStatus status) {
+    private String getReservationStatusMessage(Reservation.ReservationStatus status) {
         return switch (status) {
             case PENDING -> "대기 중";
-            case APPROVED -> "승인됨";
-            case REJECTED -> "거절됨";
-            case CANCELED -> "취소됨";
+            case CONFIRMED -> "확정됨";
+            case CANCELLED -> "취소됨";
+            default -> "알 수 없음"; // 정의되지 않은 상태 처리
         };
     }
 

--- a/backend/src/main/java/com/likelion/loco_project/domain/reservation/controller/AdminReservationController.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/reservation/controller/AdminReservationController.java
@@ -1,0 +1,24 @@
+package com.likelion.loco_project.domain.reservation.controller;
+
+import com.likelion.loco_project.domain.reservation.dto.AdminReservationResponseDto;
+import com.likelion.loco_project.domain.reservation.service.AdminReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/admin/reservations")
+@RequiredArgsConstructor
+public class AdminReservationController {
+    private final AdminReservationService adminReservationService;
+
+    @GetMapping
+    public ResponseEntity<List<AdminReservationResponseDto>> getAllReservations() {
+        List<AdminReservationResponseDto> reservations = adminReservationService.getAllReservations();
+        return ResponseEntity.ok(reservations);
+    }
+} 

--- a/backend/src/main/java/com/likelion/loco_project/domain/reservation/dto/AdminReservationResponseDto.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/reservation/dto/AdminReservationResponseDto.java
@@ -1,0 +1,33 @@
+package com.likelion.loco_project.domain.reservation.dto;
+
+import com.likelion.loco_project.domain.reservation.entity.Reservation;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class AdminReservationResponseDto {
+    private Long id;
+    private String userName;
+    private String spaceName;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private Integer totalPrice;
+    private Reservation.ReservationStatus status;
+    private Reservation.PaymentStatus paymentStatus;
+
+    public static AdminReservationResponseDto from(Reservation reservation) {
+        AdminReservationResponseDto dto = new AdminReservationResponseDto();
+        dto.setId(reservation.getId());
+        dto.setUserName(reservation.getUser().getUsername());
+        dto.setSpaceName(reservation.getSpace().getSpaceName());
+        dto.setStartTime(reservation.getStartTime());
+        dto.setEndTime(reservation.getEndTime());
+        dto.setTotalPrice(reservation.getTotalPrice());
+        dto.setStatus(reservation.getStatus());
+        dto.setPaymentStatus(reservation.getPaymentStatus());
+        return dto;
+    }
+} 

--- a/backend/src/main/java/com/likelion/loco_project/domain/reservation/entity/Reservation.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/reservation/entity/Reservation.java
@@ -3,6 +3,7 @@ package com.likelion.loco_project.domain.reservation.entity;
 import com.likelion.loco_project.domain.guest.entity.Guest;
 import com.likelion.loco_project.domain.payment.entity.Payment;
 import com.likelion.loco_project.domain.space.entity.Space;
+import com.likelion.loco_project.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -30,12 +31,31 @@ public class Reservation {
     @JoinColumn(name = "guest_id")
     private Guest guest;                                //게스트 정보
 
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;                                  //예약자 정보
+
     private LocalDateTime reservationDate;              //예약 일시
     private int bookingCapacity;                        //예약 인원
     private LocalDateTime startTime;                    //예약 시작시간
     private LocalDateTime endTime;                      //예약 끝시간
+    private Integer totalPrice;                         //총 결제 금액
 
     @Enumerated(EnumType.STRING)
-    private ReservationStatus status;                   //에약 상황
+    private ReservationStatus status;                   //예약 상태
 
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus paymentStatus;                //결제 상태
+
+    public enum ReservationStatus {
+        PENDING,    // 대기중
+        CONFIRMED,  // 확정
+        CANCELLED   // 취소
+    }
+
+    public enum PaymentStatus {
+        PAID,       // 결제완료
+        UNPAID,     // 미결제
+        REFUNDED    // 환불
+    }
 }

--- a/backend/src/main/java/com/likelion/loco_project/domain/reservation/service/AdminReservationService.java
+++ b/backend/src/main/java/com/likelion/loco_project/domain/reservation/service/AdminReservationService.java
@@ -1,0 +1,25 @@
+package com.likelion.loco_project.domain.reservation.service;
+
+import com.likelion.loco_project.domain.reservation.dto.AdminReservationResponseDto;
+import com.likelion.loco_project.domain.reservation.entity.Reservation;
+import com.likelion.loco_project.domain.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminReservationService {
+    private final ReservationRepository reservationRepository;
+
+    public List<AdminReservationResponseDto> getAllReservations() {
+        List<Reservation> reservations = reservationRepository.findAll();
+        return reservations.stream()
+                .map(AdminReservationResponseDto::from)
+                .collect(Collectors.toList());
+    }
+} 

--- a/frontend/src/app/admin/reservations/page.tsx
+++ b/frontend/src/app/admin/reservations/page.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import AdminLayout from '../../../components/AdminLayout';
+import { Card, CardContent, CardHeader } from '../../../components/Card';
+
+// TODO: 실제 예약 데이터 타입 정의 필요
+interface Reservation {
+  id: number;
+  user: string; // 예약 사용자
+  spaceName: string; // 예약 공간 이름
+  startTime: string; // 예약 시작 시간
+  endTime: string; // 예약 종료 시간
+  totalPrice: number; // 총 결제 금액
+  status: string; // 예약 상태 (예: pending, confirmed, cancelled)
+  paymentStatus: string; // 결제 상태 (예: paid, unpaid, refunded)
+}
+
+export default function AdminReservationsPage() {
+  const [reservations, setReservations] = useState<Reservation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchReservations = async () => {
+      try {
+        setLoading(true);
+        // TODO: 실제 백엔드 예약 목록 조회 API 엔드포인트로 변경
+        // const response = await fetch('/api/v1/admin/reservations'); // 예시 API 경로
+        // if (!response.ok) {
+        //   throw new Error(`HTTP error! status: ${response.status}`);
+        // }
+        // const data = await response.json();
+        // console.log('예약 목록 가져오기 성공:', data);
+
+        // TODO: 백엔드 응답 구조에 맞게 데이터 설정
+        // 현재는 예시 데이터 사용
+        const mockReservations: Reservation[] = [
+          {
+            id: 1,
+            user: '김철수',
+            spaceName: '모던한 회의실',
+            startTime: '2024-03-27 10:00',
+            endTime: '2024-03-27 12:00',
+            totalPrice: 50000,
+            status: 'confirmed',
+            paymentStatus: 'paid',
+          },
+          {
+            id: 2,
+            user: '이영희',
+            spaceName: '스튜디오B',
+            startTime: '2024-03-28 14:00',
+            endTime: '2024-03-28 17:00',
+            totalPrice: 90000,
+            status: 'pending',
+            paymentStatus: 'unpaid',
+          },
+          {
+            id: 3,
+            user: '박지민',
+            spaceName: '카페 공간',
+            startTime: '2024-03-29 09:00',
+            endTime: '2024-03-29 11:00',
+            totalPrice: 30000,
+            status: 'confirmed',
+            paymentStatus: 'paid',
+          },
+          {
+            id: 4,
+            user: '최수진',
+            spaceName: '파티룸',
+            startTime: '2024-03-30 19:00',
+            endTime: '2024-03-30 22:00',
+            totalPrice: 150000,
+            status: 'cancelled',
+            paymentStatus: 'refunded',
+          },
+          {
+            id: 5,
+            user: '정민호',
+            spaceName: '연습실',
+            startTime: '2024-03-31 13:00',
+            endTime: '2024-03-31 15:00',
+            totalPrice: 40000,
+            status: 'confirmed',
+            paymentStatus: 'paid',
+          },
+          {
+            id: 6,
+            user: '한소희',
+            spaceName: '스튜디오A',
+            startTime: '2024-04-01 11:00',
+            endTime: '2024-04-01 14:00',
+            totalPrice: 120000,
+            status: 'pending',
+            paymentStatus: 'unpaid',
+          }
+        ];
+
+        setReservations(mockReservations);
+        setError(null);
+
+      } catch (err) {
+        console.error('예약 목록 로딩 중 오류 발생:', err);
+        setError('예약 목록을 불러오는데 실패했습니다.');
+        setReservations([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchReservations();
+  }, []);
+
+  return (
+    <AdminLayout pageTitle="예약/결제 관리">
+      <div className="p-6">
+        <h1 className="text-2xl font-bold mb-6">예약 및 결제 내역</h1>
+
+        {loading ? (
+          <p>예약 목록을 불러오는 중...</p>
+        ) : error ? (
+          <div className="text-red-500">{error}</div>
+        ) : reservations.length === 0 ? (
+          <p>등록된 예약이 없습니다.</p>
+        ) : (
+          <Card>
+            <CardContent className="p-0">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      예약번호
+                    </th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      예약 사용자
+                    </th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      예약 공간
+                    </th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      예약 시간
+                    </th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      총 결제 금액
+                    </th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      예약 상태
+                    </th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      결제 상태
+                    </th>
+                    <th scope="col" className="relative px-6 py-3">
+                      <span className="sr-only">Actions</span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {reservations.map((reservation) => (
+                    <tr key={reservation.id}>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                        {reservation.id}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {reservation.user}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {reservation.spaceName}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {reservation.startTime} - {reservation.endTime}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        ₩{reservation.totalPrice.toLocaleString()}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {reservation.status}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {reservation.paymentStatus}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        {/* TODO: 상세 보기, 취소 등 액션 버튼 추가 */}
+                        <a href="#" className="text-indigo-600 hover:text-indigo-900 mr-2">상세</a>
+                        <a href="#" className="text-red-600 hover:text-red-900">취소</a>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </AdminLayout>
+  );
+} 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #90 #89 

## 📝작업 내용

- 관리자 페이지 대시보드에 전체 예약 및 결제 관리에 대한 조회 관리 추가
- [x] 예약/결제 관리 파트 구현 (관련 엔드포인트 : http://localhost:3000/admin/reservations)
- [x] 프론트엔드 예약/결제 페이지에 샘플데이터 추가
- [x] 백엔드 Admin Reservations 관련 API 추가

### 스크린샷 (선택)
![Image](https://github.com/user-attachments/assets/d90dc68b-5fb6-456c-a407-3046022008c2)

## 💬리뷰 요구사항
- ⭐현재 샘플데이터만 넣어놓은 상태입니다.

---
## 🚫닫을 이슈 (필수)
Closes #90 
