### PR TITLE
[Feature/#164] 예약 / 결제 상세 페이지 연동 및 토스 페이먼츠 테스트

### DIFF
--- a/backend/src/main/java/com/likelion/loco_project/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/likelion/loco_project/global/config/SecurityConfig.java
@@ -93,6 +93,10 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.PATCH, "/api/v1/admin/users/{userId}/role").authenticated()
                 // 호스트 전용 엔드포인트는 HOST 권한 필요
                 .requestMatchers("/api/v1/host/**").hasRole("HOST")
+                // 예약 페이지는 인증된 사용자만 접근 가능
+                .requestMatchers("/reservation").authenticated()
+                // 호스트 채팅 페이지는 인증된 사용자만 접근 가능
+                .requestMatchers("/host/chat").authenticated()
                 // 나머지는 인증 필요
                 .anyRequest().authenticated()
             )

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,7 @@
 # 프론트 단의 application.yml 역할
-NEXT_PUBLIC_KAKAO_MAP_KEY=8887d6c01d9eb7e87109bf259d22cfb5
+# 실제 키 값을 담지 않음 (실제 키 값은 .env.local 에서 관리) - .gitignore처리
+NEXT_PUBLIC_KAKAO_MAP_KEY=YOUR_KAKAO_MAP_API_KEY
+
+# 토스페이먼츠 API Key
+# 실제 키 값을 담지 않음 (실제 키 값은 .env.local 에서 관리) - .gitigrnoe처리
+NEXT_PUBLIC_TOSS_CLIENT_KEY=YOUR_TOSS_API_CLIENT_KEY

--- a/frontend/src/app/payment/page.tsx
+++ b/frontend/src/app/payment/page.tsx
@@ -3,40 +3,71 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { loadTossPayments } from "@tosspayments/payment-sdk";
+import api from '@/lib/axios'; // API 호출을 위해 axios 인스턴스 import
 
 interface PaymentInfo {
-  space: string;
+  spaceName: string; // space 대신 spaceName 사용
   date: string;
   time: string;
-  amount: number;
+  amount: number; // 임시 금액, 실제로는 백엔드에서 계산된 금액을 받아와야 함
 }
 
 export default function PaymentPage() {
   const searchParams = useSearchParams();
+  const spaceId = searchParams.get('spaceId'); // space 대신 spaceId 읽기
+  const date = searchParams.get("date");
+  const time = searchParams.get("time");
+
   const [paymentInfo, setPaymentInfo] = useState<PaymentInfo>({
-    space: "",
-    date: "",
-    time: "",
-    amount: 0,
+    spaceName: "",
+    date: date || "",
+    time: time || "",
+    amount: 0, // 초기 금액 0
   });
 
-  useEffect(() => {
-    // URL 파라미터에서 예약 정보 가져오기
-    const space = searchParams.get("space");
-    const date = searchParams.get("date");
-    const time = searchParams.get("time");
+  const [loadingSpace, setLoadingSpace] = useState(true); // 공간 정보 로딩 상태
 
-    if (space && date && time) {
-      setPaymentInfo({
-        space,
-        date,
-        time,
-        amount: 50000, // 임시 금액, 실제로는 API에서 가져와야 함
-      });
+  useEffect(() => {
+    // URL 파라미터 유효성 검사
+    if (!spaceId || !date || !time) {
+      console.error("결제 정보가 불완전합니다.");
+      // 에러 상태 표시 또는 리다이렉트 처리 필요
+      setLoadingSpace(false);
+      return;
     }
-  }, [searchParams]);
+
+    // spaceId로 공간 정보 가져오기
+    const fetchSpaceDetail = async () => {
+      try {
+        const response = await api.get(`/spaces/${spaceId}`);
+        if (response.data && response.data.data) {
+          const spaceData = response.data.data;
+          setPaymentInfo(prevInfo => ({
+            ...prevInfo,
+            spaceName: spaceData.spaceName, // 공간 이름 설정
+            amount: spaceData.price, // 공간 가격으로 결제 금액 설정 (임시)
+          }));
+        } else {
+          console.error('공간 정보를 가져오는데 실패했습니다.');
+          // 에러 상태 표시 필요
+        }
+      } catch (error) {
+        console.error("공간 정보 가져오는 중 오류 발생:", error);
+        // 에러 상태 표시 필요
+      } finally {
+        setLoadingSpace(false);
+      }
+    };
+
+    fetchSpaceDetail();
+  }, [spaceId, date, time]); // spaceId, date, time이 변경될 때마다 실행
 
   const handlePayment = async () => {
+    if (!paymentInfo.spaceName || paymentInfo.amount <= 0 || !paymentInfo.date || !paymentInfo.time) {
+        alert("결제 정보가 불완전합니다.");
+        return;
+    }
+
     try {
       const tossPayments = await loadTossPayments(
         process.env.NEXT_PUBLIC_TOSS_CLIENT_KEY!
@@ -45,15 +76,25 @@ export default function PaymentPage() {
       await tossPayments.requestPayment("카드", {
         amount: paymentInfo.amount,
         orderId: `order_${Date.now()}`,
-        orderName: `${paymentInfo.space} 예약`,
+        orderName: `${paymentInfo.spaceName} 예약`,
         customerName: "홍길동", // 실제로는 사용자 정보에서 가져와야 함
         successUrl: `${window.location.origin}/payment/success`,
         failUrl: `${window.location.origin}/payment/fail`,
       });
     } catch (error) {
       console.error("결제 처리 중 오류 발생:", error);
+       // 사용자에게 오류 메시지 표시
     }
   };
+
+  // 로딩 중이거나 공간 정보가 없으면 로딩 메시지 표시
+  if (loadingSpace || !paymentInfo.spaceName) {
+      return (
+        <div className="flex justify-center items-center min-h-screen">
+          결제 정보 로딩 중...
+        </div>
+      );
+  }
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -66,7 +107,7 @@ export default function PaymentPage() {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <p className="text-gray-600">공간</p>
-                <p className="font-medium">{paymentInfo.space}</p>
+                <p className="font-medium">{paymentInfo.spaceName}</p> {/* spaceName 표시 */}
               </div>
               <div>
                 <p className="text-gray-600">날짜</p>

--- a/frontend/src/app/reservation/page.tsx
+++ b/frontend/src/app/reservation/page.tsx
@@ -1,67 +1,133 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Calendar from "@/components/Calendar";
 import TimeSelector from "@/components/TimeSelector";
 import SpaceList from "@/components/SpaceList";
+import api from '@/lib/axios';
 
 interface ReservationState {
   selectedDate: Date | null;
   selectedTime: string;
-  selectedSpace: string;
+  spaceId: string;
 }
 
 export default function ReservationPage() {
   const router = useRouter();
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-  const [selectedTime, setSelectedTime] = useState<string>("");
-  const [selectedSpace, setSelectedSpace] = useState<string>("");
+  const searchParams = useSearchParams();
 
-  const handleReservation = async () => {
-    if (!selectedDate || !selectedTime || !selectedSpace) {
-      alert("모든 필드를 선택해주세요.");
+  const spaceId = searchParams.get('spaceId') || '';
+  const date = searchParams.get('date') || '';
+  const time = searchParams.get('time') || '';
+
+  const [space, setSpace] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isConfirmed, setIsConfirmed] = useState(false);
+
+  useEffect(() => {
+    if (!spaceId) {
+      setError('공간 정보가 누락되었습니다.');
+      setLoading(false);
       return;
     }
 
-    const formattedDate = selectedDate.toISOString().split("T")[0];
+    const fetchSpaceDetail = async () => {
+      try {
+        const response = await api.get(`/spaces/${spaceId}`);
+        if (response.data && response.data.data) {
+          setSpace(response.data.data);
+        } else {
+          setError('공간 정보를 가져오는데 실패했습니다.');
+        }
+      } catch (error) {
+        console.error('Error fetching space details:', error);
+        setError('공간 정보를 가져오는데 실패했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchSpaceDetail();
+  }, [spaceId]);
+
+  const handleReservation = async () => {
+    if (!isConfirmed) {
+      alert("날짜와 시간이 맞는지 확인해주세요.");
+      return;
+    }
+    
+    if (!space || !date || !time) {
+         alert("예약 정보가 불완전합니다.");
+         return;
+    }
+
     router.push(
-      `/payment?space=${selectedSpace}&date=${formattedDate}&time=${selectedTime}`
+      `/payment?spaceId=${space.id}&date=${date}&time=${time}`
     );
   };
 
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen">
+        로딩 중...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex justify-center items-center min-h-screen">
+        <div className="text-red-600">{error}</div>
+      </div>
+    );
+  }
+
+  if (!space) {
+     return (
+        <div className="flex justify-center items-center min-h-screen">
+           공간 정보를 찾을 수 없습니다.
+        </div>
+     );
+  }
+
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-8">공간 예약</h1>
+      <h1 className="text-3xl font-bold mb-8">공간 예약 확인</h1>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-        {/* 공간 선택 섹션 */}
         <div className="bg-white p-6 rounded-lg shadow-md">
-          <h2 className="text-xl font-semibold mb-4">공간 선택</h2>
-          <SpaceList
-            selectedSpace={selectedSpace}
-            onSelect={setSelectedSpace}
-          />
+          <h2 className="text-xl font-semibold mb-4">선택하신 공간</h2>
+          <div>
+            <h3 className="text-lg font-medium mb-2">{space.spaceName}</h3>
+            <p className="text-gray-600">{space.address}</p>
+          </div>
         </div>
 
-        {/* 날짜/시간 선택 섹션 */}
         <div className="bg-white p-6 rounded-lg shadow-md">
-          <h2 className="text-xl font-semibold mb-4">날짜 및 시간 선택</h2>
-          <div className="space-y-6">
+          <h2 className="text-xl font-semibold mb-4">예약 날짜 및 시간 확인</h2>
+          <div className="space-y-4">
             <div>
-              <h3 className="text-lg font-medium mb-2">날짜 선택</h3>
-              <Calendar
-                selectedDate={selectedDate}
-                onChange={setSelectedDate}
-              />
+              <h3 className="text-lg font-medium mb-1">선택된 날짜:</h3>
+              <p>{date}</p>
             </div>
             <div>
-              <h3 className="text-lg font-medium mb-2">시간 선택</h3>
-              <TimeSelector
-                selectedTime={selectedTime}
-                onChange={setSelectedTime}
-              />
+              <h3 className="text-lg font-medium mb-1">선택된 시간:</h3>
+              <p>{time}</p>
             </div>
+            
+            <div className="flex items-center mt-4">
+              <input 
+                type="checkbox" 
+                id="confirm" 
+                checked={isConfirmed} 
+                onChange={(e) => setIsConfirmed(e.target.checked)}
+                className="mr-2"
+              />
+              <label htmlFor="confirm">위 날짜와 시간이 맞습니까?</label>
+            </div>
+
           </div>
         </div>
       </div>
@@ -69,7 +135,8 @@ export default function ReservationPage() {
       <div className="mt-8 text-center">
         <button
           onClick={handleReservation}
-          className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors"
+          disabled={!isConfirmed}
+          className={`px-6 py-3 rounded-lg transition-colors ${isConfirmed ? 'bg-blue-600 hover:bg-blue-700 text-white' : 'bg-gray-300 text-gray-500 cursor-not-allowed'}`}
         >
           예약하기
         </button>

--- a/frontend/src/app/spaces/[id]/page.tsx
+++ b/frontend/src/app/spaces/[id]/page.tsx
@@ -10,11 +10,12 @@ import {
   Clock,
   Users,
   Star,
-  Calendar,
+  Calendar as CalendarIcon,
   ChevronRight,
 } from "lucide-react";
 import { ThemeToggle } from "@/app/components/ThemeToggle";
 import { useRouter } from "next/navigation";
+import Calendar from "@/components/Calendar";
 
 export default function SpaceDetailPage({
   params,
@@ -27,6 +28,7 @@ export default function SpaceDetailPage({
   const [error, setError] = useState<string | null>(null);
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [selectedTime, setSelectedTime] = useState<string | null>(null);
+  const [showCalendar, setShowCalendar] = useState(false);
   const router = useRouter();
 
   useEffect(() => {
@@ -123,8 +125,9 @@ export default function SpaceDetailPage({
   }, [id, router]);
 
   // 날짜/시간 선택 핸들러들...
-  const handleDateSelect = (date: Date) => {
+  const handleDateSelect = (date: Date | null) => {
     setSelectedDate(date);
+    setShowCalendar(false);
   };
   const handleTimeSelect = (time: string) => {
     setSelectedTime(time);
@@ -134,9 +137,13 @@ export default function SpaceDetailPage({
       alert("날짜와 시간을 선택해주세요.");
       return;
     }
-    alert(
-      `${selectedDate.toLocaleDateString()} ${selectedTime}에 예약이 완료되었습니다.`
-    );
+    // 예약 페이지로 이동하며 선택된 날짜와 시간, 공간 ID를 쿼리 파라미터로 전달
+    const year = selectedDate.getFullYear();
+    const month = selectedDate.getMonth() + 1;
+    const day = selectedDate.getDate();
+    const formattedDate = `${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
+
+    router.push(`/reservation?spaceId=${space.id}&date=${formattedDate}&time=${selectedTime}`);
   };
 
   if (loading) {
@@ -272,9 +279,12 @@ export default function SpaceDetailPage({
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   날짜 선택
                 </label>
-                <button className="w-full flex items-center justify-between px-4 py-2 border rounded-md">
+                <button 
+                  onClick={() => setShowCalendar(!showCalendar)}
+                  className="w-full flex items-center justify-between px-4 py-2 border rounded-md"
+                >
                   <div className="flex items-center">
-                    <Calendar size={18} className="mr-2 text-gray-500" />
+                    <CalendarIcon size={18} className="mr-2 text-gray-500" />
                     <span>
                       {selectedDate
                         ? selectedDate.toLocaleDateString()
@@ -284,6 +294,16 @@ export default function SpaceDetailPage({
                   <ChevronRight size={18} className="text-gray-500" />
                 </button>
               </div>
+
+              {/* 캘린더 표시 영역 */}
+              {showCalendar && (
+                <div className="mb-4">
+                  <Calendar 
+                    selectedDate={selectedDate}
+                    onChange={handleDateSelect}
+                  />
+                </div>
+              )}
 
               {/* 시간 선택 */}
               <div className="mb-6">
@@ -343,7 +363,7 @@ export default function SpaceDetailPage({
                     </div>
                   </div>
                   <button 
-                    onClick={() => router.push(`/host/chat?hostId=${space.host.id}`)}
+                    onClick={() => router.push(`/host/chat?hostId=${space.host.id}&spaceId=${space.id}`)}
                     className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-300 transition"
                   >
                     호스트와 채팅하기

--- a/frontend/src/app/spaces/[id]/page.tsx
+++ b/frontend/src/app/spaces/[id]/page.tsx
@@ -342,7 +342,10 @@ export default function SpaceDetailPage({
                       </Link>
                     </div>
                   </div>
-                  <button className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-300 transition">
+                  <button 
+                    onClick={() => router.push(`/host/chat?hostId=${space.host.id}`)}
+                    className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-300 transition"
+                  >
                     호스트와 채팅하기
                   </button>
                 </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #164 

## 📝작업 내용
예약 / 결제 상세 페이지 연동 및 토스 페이먼츠 

## 구현 상황

### 공간 상세페이지의 예약 정보 확인
![Image](https://github.com/user-attachments/assets/fbb642e2-9fc1-431d-8a0a-296707d9e212)

---
### 날짜 선택 캘린더 연동
![Image](https://github.com/user-attachments/assets/cb9368de-79ab-46a5-8233-baa867e49057)

---
### 캘린더 날짜 데이터 불러오기 확인
![Image](https://github.com/user-attachments/assets/8887a994-b213-4b11-8308-30d831a71249)

---
### 예약 정보 페이지 "예약 정보가 맞는지 확인하는" 체크박스 요구
![Image](https://github.com/user-attachments/assets/8a27ee41-ec92-4b11-a367-76895ea50365)
---
### 체크박스를 클릭해야 "예약하기"버튼 활성화
![Image](https://github.com/user-attachments/assets/69dd8c06-3fd0-434d-8f21-91fb623ccea2)
---
### 결제를 위한 페이지까지 연동
![Image](https://github.com/user-attachments/assets/22fdac9b-cc1f-4d03-954a-72e41e44a1ff)

---
